### PR TITLE
check variant id - use null if product is without variant #27957

### DIFF
--- a/roihunter.php
+++ b/roihunter.php
@@ -536,7 +536,10 @@ class Roihunter extends Module {
     private function createRhEasyCartItemDto() {
 
         $productId = (int)Tools::getValue("id_product");
-        $variantId = (int)Tools::getValue("ipa");
+        $variantId = null;
+        if (Tools::getValue("ipa")) {
+            $variantId = (int)Tools::getValue("ipa");
+        }
         $quantity = (int)Tools::getValue('qty');
         $price = Product::getPriceStatic($productId, $this->useTax(), $variantId);
 


### PR DESCRIPTION
variant id should be always greater than 0 otherwise return null
https://is.roihunter.com/issues/27957